### PR TITLE
[feat] Add read/write to Parser

### DIFF
--- a/SSD_Driver/SSD_Driver.vcxproj
+++ b/SSD_Driver/SSD_Driver.vcxproj
@@ -128,6 +128,9 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="parser.cpp" />
+    <ClCompile Include="parser.h" />
+    <ClCompile Include="parser_test.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/SSD_Driver/SSD_Driver.vcxproj.filters
+++ b/SSD_Driver/SSD_Driver.vcxproj.filters
@@ -18,6 +18,15 @@
     <ClCompile Include="main.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="parser.h">
+      <Filter>헤더 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="parser.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="parser_test.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/SSD_Driver/main.cpp
+++ b/SSD_Driver/main.cpp
@@ -1,4 +1,7 @@
+#include "gmock/gmock.h"
+
 int main()
 {
-	return 0;
+	::testing::InitGoogleTest();
+	return RUN_ALL_TESTS();
 }

--- a/SSD_Driver/parser.cpp
+++ b/SSD_Driver/parser.cpp
@@ -1,0 +1,2 @@
+#include "parser.h"
+

--- a/SSD_Driver/parser.cpp
+++ b/SSD_Driver/parser.cpp
@@ -1,2 +1,66 @@
 #include "parser.h"
+#include <sstream>
+#include <stdexcept>
 
+using std::vector;
+using std::string;
+using std::istringstream;
+
+vector<string> Parser::parse(const string& input) {
+	vector<string> result = split(input);
+	if (result[0] == "read") {
+		if (result.size() != 2) {
+			throw std::invalid_argument("INVALID COMMAND");
+		}
+
+		int lba;
+		try {
+			lba = std::stoi(result[1]);
+		}
+		catch (...) {
+			throw std::invalid_argument("INVALID COMMAND");
+		}
+		if (lba < 0 || lba > 99) {
+			throw std::invalid_argument("INVALID COMMAND");
+		}
+
+		return result;
+	}
+	if (result[0] == "write") {
+		if (result.size() != 3) {
+			throw std::invalid_argument("INVALID COMMAND");
+		}
+
+		int lba;
+		try {
+			lba = std::stoi(result[1]);
+		}
+		catch (...) {
+			throw std::invalid_argument("INVALID COMMAND");
+		}
+		if (lba < 0 || lba > 99) {
+			throw std::invalid_argument("INVALID COMMAND");
+		}
+
+		unsigned int value;
+		try {
+			value = std::stoul(result[2], nullptr, 16);
+		}
+		catch (...) {
+			throw std::invalid_argument("INVALID COMMAND");
+		}
+
+		return result;
+	}
+	throw std::invalid_argument("INVALID COMMAND");
+}
+
+vector<string> Parser::split(const string& input) {
+	istringstream inputStream(input);
+	vector<std::string> tokens;
+	string token;
+	while (inputStream >> token) {
+		tokens.push_back(token);
+	}
+	return tokens;
+}

--- a/SSD_Driver/parser.h
+++ b/SSD_Driver/parser.h
@@ -1,0 +1,13 @@
+#include <string>
+#include <vector>
+
+class Parser {
+public:
+	Parser() = default;
+	~Parser() = default;
+
+	std::vector<std::string> parse(const std::string& input);
+
+private:
+	std::vector<std::string> split(const std::string& input);
+};

--- a/SSD_Driver/parser_test.cpp
+++ b/SSD_Driver/parser_test.cpp
@@ -2,21 +2,41 @@
 #include "parser.h"
 #include <vector>
 #include <string>
+#include <stdexcept>
 
 using namespace testing;
 using std::string;
 using std::vector;
 
-TEST(ParserTest, ParseReadCommand) {
+class ParserFixture : public Test {
+public:
 	Parser parser;
+};
+
+TEST_F(ParserFixture, ReadSuccess) {
 	vector<string> actual = parser.parse("read 0");
 	vector<string> expected = { "read", "0" };
 	EXPECT_EQ(expected, actual);
 }
 
-TEST(ParserTest, ParseWriteCommand) {
-	Parser parser;
+TEST_F(ParserFixture, ReadInvalidLength) {
+	EXPECT_THROW(parser.parse("read 0 0xAAAABBBB"), std::invalid_argument);
+}
+
+TEST_F(ParserFixture, ReadInvalidArgument) {
+	EXPECT_THROW(parser.parse("read 255"), std::invalid_argument);
+}
+
+TEST_F(ParserFixture, WriteSuccess) {
 	vector<string> actual = parser.parse("write 3 0xAAAABBBB");
 	vector<string> expected = { "write", "3", "0xAAAABBBB" };
 	EXPECT_EQ(expected, actual);
+}
+
+TEST_F(ParserFixture, WriteInvalidLength) {
+	EXPECT_THROW(parser.parse("write 3"), std::invalid_argument);
+}
+
+TEST_F(ParserFixture, WriteInvalidArgument) {
+	EXPECT_THROW(parser.parse("write 3 0xAAAAAAAAA"), std::invalid_argument);
 }

--- a/SSD_Driver/parser_test.cpp
+++ b/SSD_Driver/parser_test.cpp
@@ -1,0 +1,13 @@
+#include "gmock/gmock.h"
+
+TEST(ParserTest, ParseReadCommand){
+	Parser parser;
+	std::vector actual = parser.parse("Read 0");
+	EXPECT_EQ(["Read", "0"], actual);
+}
+
+TEST(ParserTest, ParseWriteCommand){
+	Parser parser;
+	std::vector actual = parser.parse("write 3 0xAAAABBBB");
+	EXPECT_EQ(["write", "3", "0xAAAABBBB"], actual);
+}

--- a/SSD_Driver/parser_test.cpp
+++ b/SSD_Driver/parser_test.cpp
@@ -1,13 +1,22 @@
 #include "gmock/gmock.h"
+#include "parser.h"
+#include <vector>
+#include <string>
 
-TEST(ParserTest, ParseReadCommand){
+using namespace testing;
+using std::string;
+using std::vector;
+
+TEST(ParserTest, ParseReadCommand) {
 	Parser parser;
-	std::vector actual = parser.parse("Read 0");
-	EXPECT_EQ(["Read", "0"], actual);
+	vector<string> actual = parser.parse("read 0");
+	vector<string> expected = { "read", "0" };
+	EXPECT_EQ(expected, actual);
 }
 
-TEST(ParserTest, ParseWriteCommand){
+TEST(ParserTest, ParseWriteCommand) {
 	Parser parser;
-	std::vector actual = parser.parse("write 3 0xAAAABBBB");
-	EXPECT_EQ(["write", "3", "0xAAAABBBB"], actual);
+	vector<string> actual = parser.parse("write 3 0xAAAABBBB");
+	vector<string> expected = { "write", "3", "0xAAAABBBB" };
+	EXPECT_EQ(expected, actual);
 }


### PR DESCRIPTION
Parser에 우선 read/write를 파싱하는 기능만 추가했습니다.
Parser는 command를 token 단위로 분리하고, token을 validation합니다.
Validation check 후 문제가 없으면 vector<string> 형태로 token들을 반환합니다.

**현재 구현은 다음과 같습니다.**
- 0번째 항목을 확인하고 read 또는 write인지 확인합니다.
- read라면 길이가 2인지, 두 번째 token이 0-99까지의 숫자인지 확인합니다.
- write라면 길이가 3인지, 두 번째 token이 0-99까지의 숫자인지, 세 번째 토큰이 0x00000000-0xFFFFFFFF까지의 숫자인지 확인합니다.
- Validation에 실패하면 Invalid Argument(INVALID COMMAND) 에러가 발생합니다.

TODO: corner case에 대한 추가 검증, refactoring, 알고리즘 개선