### PR TITLE
[feat] Enable parser to handle exit/help/fullread/fullwrite commands

### DIFF
--- a/SSD_TestShell/parser.cpp
+++ b/SSD_TestShell/parser.cpp
@@ -19,8 +19,14 @@ vector<string> Parser::parse(const string& input) {
 		validateDataValue(result[2]);
 		return result;
 	}
-	if (result[0] == "exit" || result[0] == "help") {
+	if (result[0] == "exit" || result[0] == "help" || result[0] == "fullread") {
 		checkTokenCount(result, 1);
+		return result;
+	}
+	if (result[0] == "fullwrite") {
+		checkTokenCount(result, 2);
+		validateDataValue(result[1]);
+		return result;
 	}
 	throw std::invalid_argument("INVALID COMMAND");
 }

--- a/SSD_TestShell/parser.cpp
+++ b/SSD_TestShell/parser.cpp
@@ -19,6 +19,9 @@ vector<string> Parser::parse(const string& input) {
 		validateDataValue(result[2]);
 		return result;
 	}
+	if (result[0] == "exit" || result[0] == "help") {
+		checkTokenCount(result, 1);
+	}
 	throw std::invalid_argument("INVALID COMMAND");
 }
 

--- a/SSD_TestShell/test/parser_test.cpp
+++ b/SSD_TestShell/test/parser_test.cpp
@@ -53,6 +53,18 @@ TEST_F(ParserFixture, HelpSuccess) {
 	EXPECT_EQ(expected, actual);
 }
 
+TEST_F(ParserFixture, FullwriteSuccess) {
+	vector<string> actual = parser.parse("fullwrite 0xAAAABBBB");
+	vector<string> expected = { "fullwrite", "0xAAAABBBB" };
+	EXPECT_EQ(expected, actual);
+}
+
+TEST_F(ParserFixture, FullreadSuccess) {
+	vector<string> actual = parser.parse("fullread");
+	vector<string> expected = { "fullread" };
+	EXPECT_EQ(expected, actual);
+}
+
 TEST_F(ParserFixture, UnknownCommand) {
 	EXPECT_THROW(parser.parse("unknown, 0"), std::invalid_argument);
 }

--- a/SSD_TestShell/test/parser_test.cpp
+++ b/SSD_TestShell/test/parser_test.cpp
@@ -40,3 +40,19 @@ TEST_F(ParserFixture, WriteInvalidLength) {
 TEST_F(ParserFixture, WriteInvalidArgument) {
 	EXPECT_THROW(parser.parse("write 3 0xAAAAAAAAA"), std::invalid_argument);
 }
+
+TEST_F(ParserFixture, ExitSuccess) {
+	vector<string> actual = parser.parse("exit");
+	vector<string> expected = { "exit" };
+	EXPECT_EQ(expected, actual);
+}
+
+TEST_F(ParserFixture, HelpSuccess) {
+	vector<string> actual = parser.parse("help");
+	vector<string> expected = { "help" };
+	EXPECT_EQ(expected, actual);
+}
+
+TEST_F(ParserFixture, UnknownCommand) {
+	EXPECT_THROW(parser.parse("unknown, 0"), std::invalid_argument);
+}


### PR DESCRIPTION
- Parser가, SSD가 지원하는 모든 명령어를 지원합니다.
- 관련 unit test 및 unknown command가 들어온 경우 unit test를 추가했습니다.
- Test script 관련은 추후 추가 예정입니다.