### PR TITLE
checker interface & mock & test script update

### DIFF
--- a/SSD_TestShell/command_mock.h
+++ b/SSD_TestShell/command_mock.h
@@ -7,3 +7,10 @@ public:
 	MOCK_METHOD(void, set, (const string cmd), (override));
 	MOCK_METHOD(bool, run, (), (override));
 };
+
+class CheckerMock : public Checker{
+public:
+	MOCK_METHOD(bool, nandWriteAndReadAndChecker, (int, const string&), (override));
+	MOCK_METHOD(bool, nandReadAndChecker, (int, const string&), (override));
+	MOCK_METHOD(bool, nandOutputChecker, (string), (override));
+};

--- a/SSD_TestShell/shell_command.h
+++ b/SSD_TestShell/shell_command.h
@@ -8,3 +8,10 @@ public:
 	virtual void set(const string cmd) = 0;
 	virtual bool run() = 0;
 };
+
+class Checker {
+public:
+	virtual bool nandWriteAndReadAndChecker(int LBA, const string& data) = 0;
+	virtual bool nandReadAndChecker(int LBA, const string& data) = 0;
+	virtual bool nandOutputChecker(string data) = 0;
+};

--- a/SSD_TestShell/test_script.cpp
+++ b/SSD_TestShell/test_script.cpp
@@ -5,50 +5,148 @@
 #include <string>
 #include <sstream>
 
+
 class TestScript {
 public:
-	TestScript(Command* cm) : cm{ cm } {}
+	TestScript(Command* cm, Checker* cc) : cm{ cm }, cc{ cc } {}
 
 	void fullWriteAndReadCompare() {
+		bool result;
 		for (int i = 0; i < 100; i += 4) {
 			static std::mt19937 gen(std::random_device{}());
 			std::uniform_int_distribution<uint32_t>dist(0, 0xFFFFFFFF);
 			uint32_t value = dist(gen);
 
 			std::ostringstream oss;
-			oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << value;
 
 			for (int j = 0; j < 4; j++) {
-				cm->set("W " + std::to_string(j) + " " + oss.str());
-				cm->run();
+				oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << value;
+				string randData = oss.str();
+
+				cm->set("W " + std::to_string(j) + " " + randData);
+				result = cm->run();
+				if (!result) {
+					std::cout << "FAIL";
+					return;
+				}
 				cm->set("R " + std::to_string(j));
-				cm->run();
-				// TODO
-				// ssd_nand.txt와 ssd_output.txt 확인하여 같은지 확인
-				// 다르면 FAIL 출력
+				result = cm->run();
+				if (!result) {
+					std::cout << "FAIL";
+					return;
+				}
+
+				result = cc->nandOutputChecker(randData);
+				if (!result) {
+					std::cout << "FAIL";
+					return;
+				}
 			}
 		}
 
-		std::cout << "PASS" << std::endl;
+		std::cout << "PASS";
 
 	}
 
 	void partialLBAWrite() {
+		bool result;
+		
+		static std::mt19937 gen(std::random_device{}());
+		std::uniform_int_distribution<uint32_t>dist(0, 0xFFFFFFFF);
+		uint32_t value = dist(gen);
 
-		for (int i = 0; i < 120; i++) {
-			cm->set("W");
-			cm->run();
+		std::ostringstream oss;
+		
+		for (int i = 0; i < 30; i++) {
+			oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << value;
+			string randData = oss.str();
+
+			cm->set("W " + std::to_string(4) + " " + randData);
+			result = cm->run();
+			if (!result) {
+				std::cout << "FAIL";
+				return;
+			}
+			cm->set("W " + std::to_string(0) + " " + randData);
+			result = cm->run();
+			if (!result) {
+				std::cout << "FAIL";
+				return;
+			}
+			cm->set("W " + std::to_string(3) + " " + randData);
+			result = cm->run();
+			if (!result) {
+				std::cout << "FAIL";
+				return;
+			}
+			cm->set("W " + std::to_string(1) + " " + randData);
+			result = cm->run();
+			if (!result) {
+				std::cout << "FAIL";
+				return;
+			}
+			cm->set("W " + std::to_string(2) + " " + randData);
+			result = cm->run();
+			if (!result) {
+				std::cout << "FAIL";
+				return;
+			}
+
+			for (int j = 0; j < 5; j++) {
+				result = cc->nandReadAndChecker(j, randData);
+				if (!result) {
+					std::cout << "FAIL";
+					return;
+				}
+			}
 		}
+
+		std::cout << "PASS";
 	}
 
 	void writeReadAging() {
+		bool result;
 
-		for (int i = 0; i < 400; i++) {
-			cm->set("W");
-			cm->run();
+		static std::mt19937 gen(std::random_device{}());
+		std::uniform_int_distribution<uint32_t>dist(0, 0xFFFFFFFF);
+		uint32_t value = dist(gen);
+
+		std::ostringstream oss;
+
+		for (int i = 0; i < 200; i++) {
+			oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << value;
+			string randData1 = oss.str();
+
+			cm->set("W " + std::to_string(0) + " " + randData1);
+			result = cm->run();
+			if (!result) {
+				std::cout << "FAIL";
+				return;
+			}
+
+			oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << value;
+			string randData2 = oss.str();
+
+			cm->set("W " + std::to_string(99) + " " + randData2);
+			result = cm->run();
+			if (!result) {
+				std::cout << "FAIL";
+				return;
+			}
+
+			result = cc->nandReadAndChecker(99, randData1);
+
+			if (result) {
+				std::cout << "FAIL";
+				return;
+			}
 		}
+
+		std::cout << "PASS";
 	}
 
 private:
 	Command* cm;
+	Checker* cc;
+
 };

--- a/SSD_TestShell/test_script_test.cpp
+++ b/SSD_TestShell/test_script_test.cpp
@@ -2,43 +2,249 @@
 #include "shell_command.h"
 #include "test_script.cpp"
 
+#include <iostream>
+#include <sstream>
+
+
 using namespace testing;
 
-TEST(TS, TC1) {
+TEST(TS, FullWriteAndReadComapre_Test1) {
 	CommandMock cm;
-	TestScript ts{ &cm };
+	CheckerMock cc;
+	TestScript ts{ &cm, &cc };
 
+	std::ostringstream oss;
+	std::streambuf* old_buf;
+
+	old_buf = std::cout.rdbuf(oss.rdbuf());  // cout redirection
+
+	// Command operation count check
 	EXPECT_CALL(cm, run())
-		.Times(200);
-		
+		.Times(200)
+		.WillRepeatedly(Return(true));
 	EXPECT_CALL(cm, set(_))
 		.Times(200);
+
+	EXPECT_CALL(cc, nandOutputChecker(_))
+		.WillRepeatedly(Return(true));
 
 	ts.fullWriteAndReadCompare();
+
+	// PASS string check
+	EXPECT_EQ(oss.str(), "PASS");
+
+	std::cout.rdbuf(old_buf);  // origin rdbuf  restore
 }
 
-TEST(TS, TC2) {
+TEST(TS, FullWriteAndReadComapre_Test2) {
 	CommandMock cm;
-	TestScript ts{ &cm };
+	CheckerMock cc;
+	TestScript ts{ &cm, &cc };
 
+	std::ostringstream oss;
+	std::streambuf* old_buf;
+
+	old_buf = std::cout.rdbuf(oss.rdbuf());  // cout redirection
+
+	// run fail check
+	EXPECT_CALL(cm, set(_));
 	EXPECT_CALL(cm, run())
-		.Times(120);
+		.WillRepeatedly(Return(false));
 
+	EXPECT_CALL(cc, nandOutputChecker(_))
+		.WillRepeatedly(Return(true));
+
+	ts.fullWriteAndReadCompare();
+
+	// FAIL string check
+	EXPECT_EQ(oss.str(), "FAIL");
+
+	std::cout.rdbuf(old_buf);  // origin rdbuf  restore
+}
+
+TEST(TS, FullWriteAndReadComapre_Test3) {
+	CommandMock cm;
+	CheckerMock cc;
+	TestScript ts{ &cm, &cc };
+
+	std::ostringstream oss;
+	std::streambuf* old_buf;
+
+	old_buf = std::cout.rdbuf(oss.rdbuf());  // cout redirection
+
+	// nandOutputChecker fail check
 	EXPECT_CALL(cm, set(_))
-		.Times(120);
+		.Times(2);
+	EXPECT_CALL(cm, run())
+		.WillRepeatedly(Return(true));
+	
+	EXPECT_CALL(cc, nandOutputChecker(_))
+		.WillRepeatedly(Return(false));
+
+	ts.fullWriteAndReadCompare();
+
+	// FAIL string check
+	EXPECT_EQ(oss.str(), "FAIL");
+
+	std::cout.rdbuf(old_buf);  // origin rdbuf  restore
+}
+
+TEST(TS, PartalLBAWrite_Test1) {
+	CommandMock cm;
+	CheckerMock cc;
+	TestScript ts{ &cm, &cc };
+
+	std::ostringstream oss;
+	std::streambuf* old_buf;
+
+	old_buf = std::cout.rdbuf(oss.rdbuf());  // cout redirection
+
+	// Command operation count check
+	EXPECT_CALL(cm, run())
+		.Times(150)
+		.WillRepeatedly(Return(true));
+	EXPECT_CALL(cm, set(_))
+		.Times(150);
+
+	EXPECT_CALL(cc, nandReadAndChecker(_, _))
+		.Times(150)
+		.WillRepeatedly(Return(true));
 
 	ts.partialLBAWrite();
+
+	// PASS string check
+	EXPECT_EQ(oss.str(), "PASS");
+
+	std::cout.rdbuf(old_buf);  // origin rdbuf  restore
 }
 
-TEST(TS, TC3) {
+TEST(TS, PartalLBAWrite_Test2) {
 	CommandMock cm;
-	TestScript ts{ &cm };
+	CheckerMock cc;
+	TestScript ts{ &cm, &cc };
 
+	std::ostringstream oss;
+	std::streambuf* old_buf;
+
+	old_buf = std::cout.rdbuf(oss.rdbuf());  // cout redirection
+
+	// run fail check
+	EXPECT_CALL(cm, set(_));
 	EXPECT_CALL(cm, run())
-		.Times(400);
+		.WillRepeatedly(Return(false));
+	
+	ts.partialLBAWrite();
 
+	// FAIL string check
+	EXPECT_EQ(oss.str(), "FAIL");
+
+	std::cout.rdbuf(old_buf);  // origin rdbuf  restore
+}
+
+TEST(TS, PartalLBAWrite_Test3) {
+	CommandMock cm;
+	CheckerMock cc;
+	TestScript ts{ &cm, &cc };
+
+	std::ostringstream oss;
+	std::streambuf* old_buf;
+
+	old_buf = std::cout.rdbuf(oss.rdbuf());  // cout redirection
+
+	// run fail check
+	EXPECT_CALL(cm, set(_))
+		.Times(5);
+	EXPECT_CALL(cm, run())
+		.Times(5)
+		.WillRepeatedly(Return(true));
+	
+	EXPECT_CALL(cc, nandReadAndChecker(_, _))
+		.WillRepeatedly(Return(false));
+
+	ts.partialLBAWrite();
+
+	// FAIL string check
+	EXPECT_EQ(oss.str(), "FAIL");
+
+	std::cout.rdbuf(old_buf);  // origin rdbuf  restore
+}
+
+TEST(TS, WriteReadAging_Test1) {
+	CommandMock cm;
+	CheckerMock cc;
+	TestScript ts{ &cm, &cc };
+
+	std::ostringstream oss;
+	std::streambuf* old_buf;
+
+	old_buf = std::cout.rdbuf(oss.rdbuf());  // cout redirection
+
+	// Command operation count check
 	EXPECT_CALL(cm, set(_))
 		.Times(400);
+	EXPECT_CALL(cm, run())
+		.Times(400)
+		.WillRepeatedly(Return(true));
+
+	EXPECT_CALL(cc, nandReadAndChecker(_,_))
+		.Times(200)
+		.WillRepeatedly(Return(false));
 
 	ts.writeReadAging();
+
+	// PASS string check
+	EXPECT_EQ(oss.str(), "PASS");
+
+	std::cout.rdbuf(old_buf);  // origin rdbuf  restore
+}
+
+TEST(TS, WriteReadAging_Test2) {
+	CommandMock cm;
+	CheckerMock cc;
+	TestScript ts{ &cm, &cc };
+
+	std::ostringstream oss;
+	std::streambuf* old_buf;
+
+	old_buf = std::cout.rdbuf(oss.rdbuf());  // cout redirection
+
+	// run fail check
+	EXPECT_CALL(cm, set(_));
+	EXPECT_CALL(cm, run())
+		.WillRepeatedly(Return(false));
+
+	ts.writeReadAging();
+
+	// FAIL string check
+	EXPECT_EQ(oss.str(), "FAIL");
+
+	std::cout.rdbuf(old_buf);  // origin rdbuf  restore
+}
+
+TEST(TS, WriteReadAging_Test3) {
+	CommandMock cm;
+	CheckerMock cc;
+	TestScript ts{ &cm, &cc };
+
+	std::ostringstream oss;
+	std::streambuf* old_buf;
+
+	old_buf = std::cout.rdbuf(oss.rdbuf());  // cout redirection
+
+	// Command operation count check
+	EXPECT_CALL(cm, set(_))
+		.Times(2);
+	EXPECT_CALL(cm, run())
+		.Times(2)
+		.WillRepeatedly(Return(true));
+
+	EXPECT_CALL(cc, nandReadAndChecker(_,_))
+		.WillRepeatedly(Return(true));
+
+	ts.writeReadAging();
+
+	// FAIL string check
+	EXPECT_EQ(oss.str(), "FAIL");
+
+	std::cout.rdbuf(old_buf);  // origin rdbuf  restore
 }


### PR DESCRIPTION
[feature] checker interface & mock init upload
- test script를  TDD를 진행하기 위해 ssd_nand.txt, ssd_output.txt dummy를 구성하기 보다는 SSD 데이터 정합성을 확인하는 checker mock을 구성하였습니다.

[feature] test script test & function update
- test script에 대하여 command, checker를 활용했을때 각각 3가지 PASS, FAIL 케이스를 구성하여 TEST를 구성한 뒤 확인하였습니다.
- command, checker에 대한 mock을 활용하기 위해 command, checker를 생성자 인자로 전달 받아야합니다.