### PR TITLE
[Feature] Add ssd_verify_app

### DIFF
--- a/SSD_TestShell/SSD_TestShell.vcxproj
+++ b/SSD_TestShell/SSD_TestShell.vcxproj
@@ -142,6 +142,10 @@
     <ClCompile Include="parser\validator_utils.cpp" />
     <ClCompile Include="read_command.cpp" />
     <ClCompile Include="ssd_handler.cpp" />
+    <ClCompile Include="ssd_verify_app.cpp">
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)\parser;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <ClCompile Include="ssd_verify_app_test.cpp" />
     <ClCompile Include="test\test_command_processer.cpp">
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'"> %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
@@ -168,6 +172,7 @@
     <ClInclude Include="read_command.h" />
     <ClInclude Include="shell_command.h" />
     <ClInclude Include="ssd_handler.h" />
+    <ClInclude Include="ssd_verify_app.h" />
     <ClInclude Include="write_command.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/SSD_TestShell/main.cpp
+++ b/SSD_TestShell/main.cpp
@@ -7,9 +7,15 @@ int main(int argc, char** argv) {
     return RUN_ALL_TESTS();
 }
 #else
+#include "ssd_verify_app.h"
 #include <iostream>
-int main(int argc, char** argv) {
+int main() {
     std::cout << "Release\n";
+
+    SsdVerifyApp app;
+    app.getUserCmdLine();
+    app.startVerify();
+
     return 0;
 }
 #endif

--- a/SSD_TestShell/ssd_verify_app.cpp
+++ b/SSD_TestShell/ssd_verify_app.cpp
@@ -1,0 +1,29 @@
+#include <iostream>
+#include <vector>
+#include "ssd_verify_app.h"
+#include "parser/parser.h"
+#include "command_processer.h"
+
+using std::string;
+using std::vector;
+using std::cout;
+using std::cin;
+
+void SsdVerifyApp::startVerify() {
+	Parser parser;
+	vector<string> parsedInput = parser.parse(inputCmd);
+
+	CommandProcesser commandProcesser;
+	commandProcesser.run(parsedInput);
+}
+
+void SsdVerifyApp::setInputCmd(string input) {
+	inputCmd = input;
+}
+
+void SsdVerifyApp::getUserCmdLine() {
+	cout << "Shell> ";
+	string input;
+	getline(cin, input);
+	setInputCmd(input);
+}

--- a/SSD_TestShell/ssd_verify_app.h
+++ b/SSD_TestShell/ssd_verify_app.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+
+class SsdVerifyApp {
+public:
+	void startVerify();
+	void setInputCmd(std::string input);
+	void getUserCmdLine();
+private:
+	std::string inputCmd;
+};

--- a/SSD_TestShell/ssd_verify_app_test.cpp
+++ b/SSD_TestShell/ssd_verify_app_test.cpp
@@ -1,0 +1,36 @@
+#include "gmock/gmock.h"
+#include "ssd_verify_app.h"
+#include "command_processer.h"
+
+using namespace testing;
+
+class SsdVerifyAppFixture : public Test {
+public:
+	std::ostringstream oss;
+	std::streambuf* old_buf;
+
+private:
+	void SetUp() override {
+		old_buf = std::cout.rdbuf(oss.rdbuf());
+	}
+
+	void TearDown() override {
+		std::cout.rdbuf(old_buf);
+	}
+};
+
+TEST_F(SsdVerifyAppFixture, ReadSuccess) {
+	SsdVerifyApp app;
+	app.setInputCmd("read 0");
+	app.startVerify();
+
+	EXPECT_EQ(oss.str(), "[Read] LBA 0 : 0x00000000\n");
+}
+
+TEST_F(SsdVerifyAppFixture, WriteSuccess) {
+	SsdVerifyApp app;
+	app.setInputCmd("write 3 0xAAAABBBB");
+	app.startVerify();
+
+	EXPECT_EQ(oss.str(), "[Write] Done\n");
+}


### PR DESCRIPTION
main에 들어갈 ssd_verify_app 추가했습니다.
user cmd를 입력 받고 parse 및 cmd의 run을 호출합니다.
cin으로 입력받는 부분은 test로 처리하기 어려워 직접 cmd를 넣어주었습니다.