### PR TITLE
test script command init upload

### DIFF
--- a/SSD_TestShell/checker.cpp
+++ b/SSD_TestShell/checker.cpp
@@ -1,0 +1,14 @@
+#include "checker.h"
+
+bool OutputChecker::outputChecker(const string& data) {
+		std::ifstream ssdOutput("ssd_output.txt");
+		string outputData;
+
+		if (ssdOutput.is_open()) {
+			if (!std::getline(ssdOutput, outputData)) return false;
+		}
+		ssdOutput.close();
+
+		if (outputData != data) return false;
+		return true;
+}

--- a/SSD_TestShell/checker.h
+++ b/SSD_TestShell/checker.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "gmock/gmock.h"
+#include <string>
+#include <iomanip>
+#include <random>
+#include <iostream>
+#include <sstream>
+#include <fstream>
+
+using std::string;
+
+class Checker {
+public:
+	virtual bool outputChecker(const string& data) = 0;
+};
+
+class OutputChecker : public Checker {
+public:
+	bool outputChecker(const string& data) override;
+};
+
+class OutputCheckerMock : public Checker {
+public:
+	MOCK_METHOD(bool, outputChecker, (const string&), (override));
+};

--- a/SSD_TestShell/full_write_and_read_compare_command.cpp
+++ b/SSD_TestShell/full_write_and_read_compare_command.cpp
@@ -1,0 +1,29 @@
+#include "full_write_and_read_compare_command.h"
+
+using std::cout;
+
+void FullWriteAndReadCompareCommand::run(vector<string> commands) {
+	static std::mt19937 gen(std::random_device{}());
+	std::uniform_int_distribution<uint32_t>dist(0, 0xFFFFFFFF);
+	std::ostringstream oss;
+
+	for (int i = 0; i < 100; i += 4) {
+		uint32_t value = dist(gen);
+	
+		for (int LBA = i; LBA < i + 4; LBA++) {
+			oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << value;
+			string randData = oss.str();
+
+			ssd->write(std::to_string(LBA), randData);
+			ssd->read(std::to_string(LBA));
+
+			bool result = cc->outputChecker(randData);
+			if (!result) {
+				std::cout << "FAIL";
+				return;
+			}
+		}
+	}
+
+	std::cout << "PASS";
+}

--- a/SSD_TestShell/full_write_and_read_compare_command.h
+++ b/SSD_TestShell/full_write_and_read_compare_command.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "command.h"
+#include <iomanip>
+#include <random>
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <fstream>
+#include "ssd_handler.h"
+#include "checker.h"
+
+class FullWriteAndReadCompareCommand : public Command {
+public:
+	FullWriteAndReadCompareCommand(SsdInterface* ssd, Checker* cc) : ssd{ ssd }, cc{ cc } {}
+	void run(vector<string> commands) override;
+private:
+	SsdInterface* ssd;
+	Checker* cc;
+};

--- a/SSD_TestShell/partial_lba_write_command.cpp
+++ b/SSD_TestShell/partial_lba_write_command.cpp
@@ -1,0 +1,33 @@
+#include "partial_lba_write_command.h"
+
+using std::cout;
+
+void PartialLBAWriteCommand::run(vector<string> commands) {
+	static std::mt19937 gen(std::random_device{}());
+	std::uniform_int_distribution<uint32_t>dist(0, 0xFFFFFFFF);
+	std::ostringstream oss;
+
+	for (int i = 0; i < 30; i++) {
+		uint32_t value = dist(gen);
+		oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << value;
+		string randData = oss.str();
+
+		ssd->write(std::to_string(4), randData);
+		ssd->write(std::to_string(0), randData);
+		ssd->write(std::to_string(3), randData);
+		ssd->write(std::to_string(1), randData);
+		ssd->write(std::to_string(0), randData);
+
+		for (int LBA = 0; LBA < 5; LBA++) {
+			ssd->read(std::to_string(LBA));
+
+			bool result = cc->outputChecker(randData);
+			if (!result) {
+				std::cout << "FAIL";
+				return;
+			}
+		}
+	}
+
+	std::cout << "PASS";
+}

--- a/SSD_TestShell/partial_lba_write_command.h
+++ b/SSD_TestShell/partial_lba_write_command.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "command.h"
+#include <iomanip>
+#include <random>
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <fstream>
+#include "ssd_handler.h"
+#include "checker.h"
+
+class PartialLBAWriteCommand : public Command {
+public:
+	PartialLBAWriteCommand(SsdInterface* ssd, Checker* cc) : ssd{ ssd }, cc{ cc } {}
+	void run(vector<string> commands) override;
+private:
+	SsdInterface* ssd;
+	Checker* cc;
+};

--- a/SSD_TestShell/ssd_handler.h
+++ b/SSD_TestShell/ssd_handler.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include "gmock/gmock.h"
 #include "string"
 
 #define interface class
@@ -7,8 +7,8 @@ using std::string;
 
 interface SsdInterface {
 public:
-	virtual void read(string lba);
-	virtual void write(string lba, string data);
+	virtual void read(string lba) = 0;
+	virtual void write(string lba, string data) = 0;
 };
 
 class SsdHandler : public SsdInterface {
@@ -17,4 +17,10 @@ public :
 	void write(string lba, string data) override;
 private:
 	void runSSD(std::string cmd);
+};
+
+class SsdHandlerMock : public SsdInterface {
+public:
+	MOCK_METHOD(void, read, (string), (override));
+	MOCK_METHOD(void, write, (string, string), (override));
 };

--- a/SSD_TestShell/write_read_aging_command.cpp
+++ b/SSD_TestShell/write_read_aging_command.cpp
@@ -1,0 +1,34 @@
+#include "write_read_aging_command.h"
+
+using std::cout;
+
+void WriteReadAgingCommand::run(vector<string> commands) {
+	static std::mt19937 gen(std::random_device{}());
+	std::uniform_int_distribution<uint32_t>dist(0, 0xFFFFFFFF);
+	std::ostringstream oss;
+
+	for (int i = 0; i < 200; i++) {
+		uint32_t value = dist(gen);
+		oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << value;
+		string randData = oss.str();
+
+		ssd->write(std::to_string(0), randData);
+		ssd->write(std::to_string(99), randData);
+
+		ssd->read(std::to_string(0));
+		bool result = cc->outputChecker(randData);
+		if (!result) {
+			std::cout << "FAIL";
+			return;
+		}
+
+		ssd->read(std::to_string(99));
+		result = cc->outputChecker(randData);
+		if (!result) {
+			std::cout << "FAIL";
+			return;
+		}
+	}
+
+	std::cout << "PASS";
+}

--- a/SSD_TestShell/write_read_aging_command.h
+++ b/SSD_TestShell/write_read_aging_command.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "command.h"
+#include <iomanip>
+#include <random>
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <fstream>
+#include "ssd_handler.h"
+#include "checker.h"
+
+class WriteReadAgingCommand : public Command {
+public:
+	WriteReadAgingCommand(SsdInterface* ssd, Checker* cc) : ssd{ ssd }, cc{ cc } {}
+	void run(vector<string> commands) override;
+private:
+	SsdInterface* ssd;
+	Checker* cc;
+};


### PR DESCRIPTION
[feature] ssdHandlerMock add
- ssdHandlerMock 추가

[feature] ssd_output.txt data checker init upload
- ssd_output.txt 파일의 데이터를 arg로 들어오는 string과 동일한지 확인하는 checker 추가
- ssd_output.txt를 직접 읽는것 대신 mock으로 test script를 TEST할때 주로 활용

[feature] test script command init upload
- 3가지 test script에 대하여 command interface를 상속받아 구현
- run(commands)로 동작하는것은 동일하나 commands의 데이터와 무관하게 동작