### PR TITLE
[refactor] Introduce ValidatorFactory for Parser

### DIFF
--- a/SSD_TestShell/SSD_TestShell.vcxproj
+++ b/SSD_TestShell/SSD_TestShell.vcxproj
@@ -164,6 +164,7 @@
     <ClInclude Include="help_command.h" />
     <ClInclude Include="parser\parser.h" />
     <ClInclude Include="parser\validator.h" />
+    <ClInclude Include="parser\validator_factory.h" />
     <ClInclude Include="parser\validator_utils.h" />
     <ClInclude Include="read_command.h" />
     <ClInclude Include="shell_command.h" />

--- a/SSD_TestShell/parser/parser.cpp
+++ b/SSD_TestShell/parser/parser.cpp
@@ -1,5 +1,5 @@
 #include "parser.h"
-#include "validator_utils.h"
+#include "validator_factory.h"
 #include <sstream>
 #include <stdexcept>
 
@@ -8,28 +8,16 @@ using std::string;
 using std::istringstream;
 
 vector<string> Parser::parse(const string& input) {
-	vector<string> result = split(input);
-	if (result[0] == "read") {
-		ValidatorUtils::checkTokenCount(result, 2);
-		ValidatorUtils::validateAddress(result[1]);
-		return result;
+	vector<string> tokens = split(input);
+
+	if (tokens.empty()) {
+		throw std::invalid_argument("INVALID COMMAND");
 	}
-	if (result[0] == "write") {
-		ValidatorUtils::checkTokenCount(result, 3);
-		ValidatorUtils::validateAddress(result[1]);
-		ValidatorUtils::validateDataValue(result[2]);
-		return result;
-	}
-	if (result[0] == "exit" || result[0] == "help" || result[0] == "fullread") {
-		ValidatorUtils::checkTokenCount(result, 1);
-		return result;
-	}
-	if (result[0] == "fullwrite") {
-		ValidatorUtils::checkTokenCount(result, 2);
-		ValidatorUtils::validateDataValue(result[1]);
-		return result;
-	}
-	throw std::invalid_argument("INVALID COMMAND");
+
+	auto validator = ValidatorFactory::createValidator(tokens[0]);
+	validator->validate(tokens);
+
+	return tokens;
 }
 
 vector<string> Parser::split(const string& input) {

--- a/SSD_TestShell/parser/validator.h
+++ b/SSD_TestShell/parser/validator.h
@@ -1,0 +1,51 @@
+#include <string>
+#include <vector>
+#include "validator_utils.h"
+
+class Validator {
+public:
+	Validator() = default;
+	~Validator() = default;
+
+	virtual void validate(const std::vector<std::string> token) = 0;
+};
+
+class ReadValidator : public Validator {
+public:
+	void validate(const std::vector<std::string> tokens) override {
+		ValidatorUtils::checkTokenCount(tokens, EXPECTED_NUM_TOKENS);
+		ValidatorUtils::validateAddress(tokens[1]);
+	}
+private:
+	const size_t EXPECTED_NUM_TOKENS = 2;
+};
+
+class WriteValidator : public Validator {
+public:
+	void validate(const std::vector<std::string> tokens) override {
+		ValidatorUtils::checkTokenCount(tokens, EXPECTED_NUM_TOKENS);
+		ValidatorUtils::validateAddress(tokens[1]);
+		ValidatorUtils::validateDataValue(tokens[2]);
+	}
+private:
+	const size_t EXPECTED_NUM_TOKENS = 3;
+};
+
+class FullWriteValidator : public Validator {
+public:
+	void validate(const std::vector<std::string> tokens) override {
+		ValidatorUtils::checkTokenCount(tokens, EXPECTED_NUM_TOKENS);
+		ValidatorUtils::validateDataValue(tokens[1]);
+	}
+private:
+	const size_t EXPECTED_NUM_TOKENS = 2;
+};
+
+class SimpleValidator : public Validator {
+public:
+	void validate(const std::vector<std::string> tokens) override {
+		ValidatorUtils::checkTokenCount(tokens, EXPECTED_NUM_TOKENS);
+	}
+private:
+	const size_t EXPECTED_NUM_TOKENS = 1;
+};

--- a/SSD_TestShell/parser/validator_factory.h
+++ b/SSD_TestShell/parser/validator_factory.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <stdexcept>
+#include "validator.h"
+
+class ValidatorFactory {
+public:
+	static std::unique_ptr<Validator> createValidator(const std::string& command) {
+		if (command == "read") {
+			return std::make_unique<ReadValidator>();
+		}
+		if (command == "write") {
+			return std::make_unique<WriteValidator>();
+		}
+		if (command == "fullwrite") {
+			return std::make_unique<FullWriteValidator>();
+		}
+		if (command == "fullread" || command == "exit" || command == "help") {
+			return std::make_unique<SimpleValidator>();
+		}
+
+		throw std::invalid_argument("INVALID COMMAND");
+	}
+};


### PR DESCRIPTION
기존에는 Parser::parse method 안에서 if-else문을 통해 각각의 명령어를 validate 했습니다.

이 PR에서는 확장성을 고려하여 각 명령어마다 Validator class를 생성하고,
Simple Factory를 통해 Parser가 간단히 이들을 생성하고 사용하도록 했습니다.

명령어가 추가되면 Validator class만 추가하면 되고,
Parser는 명령어를 token으로 분해, Validator는 분해된 token의 유효성을 검증하므로 Responsibility도 깔끔합니다.