### PR TITLE
[feat] Enable parser to handle erase/flush command

### DIFF
--- a/SSD_TestShell/parser/validator.h
+++ b/SSD_TestShell/parser/validator.h
@@ -41,6 +41,17 @@ private:
 	const size_t EXPECTED_NUM_TOKENS = 2;
 };
 
+class EraseValidator : public Validator {
+public:
+	void validate(const std::vector<std::string> tokens) override {
+		ValidatorUtils::checkTokenCount(tokens, EXPECTED_NUM_TOKENS);
+		ValidatorUtils::checkInteger(tokens[1]);
+		ValidatorUtils::checkInteger(tokens[2]);
+	}
+private:
+	const size_t EXPECTED_NUM_TOKENS = 3;
+};
+
 class SimpleValidator : public Validator {
 public:
 	void validate(const std::vector<std::string> tokens) override {

--- a/SSD_TestShell/parser/validator_factory.h
+++ b/SSD_TestShell/parser/validator_factory.h
@@ -18,7 +18,10 @@ public:
 		if (command == "fullwrite") {
 			return std::make_unique<FullWriteValidator>();
 		}
-		if (command == "fullread" || command == "exit" || command == "help") {
+		if (command == "erase") {
+			return std::make_unique<EraseValidator>();
+		}
+		if (command == "fullread" || command == "exit" || command == "help" || command == "flush") {
 			return std::make_unique<SimpleValidator>();
 		}
 		if (command == "1_" || command == "2_" || command == "3_" ||

--- a/SSD_TestShell/test/parser_test.cpp
+++ b/SSD_TestShell/test/parser_test.cpp
@@ -89,6 +89,23 @@ TEST_F(ParserFixture, ScriptShortSuccess) {
 	EXPECT_EQ(expected, actual);
 }
 
+TEST_F(ParserFixture, EraseSuccess) {
+	vector<string> actual = parser.parse("erase 1 30");
+	vector<string> expected = { "erase", "1", "30" };
+	EXPECT_EQ(expected, actual);
+}
+
+TEST_F(ParserFixture, EraseInvalidArgument) {
+	vector<string> actual = parser.parse("erase foo 30");
+	EXPECT_THROW(parser.parse("erase foo 30"), std::invalid_argument);
+}
+
+TEST_F(ParserFixture, FlushSuccess) {
+	vector<string> actual = parser.parse("flush");
+	vector<string> expected = { "flush" };
+	EXPECT_EQ(expected, actual);
+}
+
 TEST_F(ParserFixture, UnknownCommand) {
 	EXPECT_THROW(parser.parse("unknown, 0"), std::invalid_argument);
 }

--- a/SSD_TestShell/test/parser_test.cpp
+++ b/SSD_TestShell/test/parser_test.cpp
@@ -96,7 +96,6 @@ TEST_F(ParserFixture, EraseSuccess) {
 }
 
 TEST_F(ParserFixture, EraseInvalidArgument) {
-	vector<string> actual = parser.parse("erase foo 30");
 	EXPECT_THROW(parser.parse("erase foo 30"), std::invalid_argument);
 }
 


### PR DESCRIPTION
Parser가 이제 erase와 flush command를 처리할 수 있습니다.
Unit test도 추가했습니다.