### PR TITLE
[fix] test script result add line break string & rand data string clear fix

### DIFF
--- a/SSD_TestShell/erase_and_write_aging_command.cpp
+++ b/SSD_TestShell/erase_and_write_aging_command.cpp
@@ -7,8 +7,8 @@ void EraseAndWriteAgingCommand::run(vector<string> commands) {
 	std::uniform_int_distribution<uint32_t>dist(0, 0xFFFFFFFF);
 	std::ostringstream oss;
 
+	ssd->erase(std::to_string(0), std::to_string(3));
 	for (int i = 0; i < 30; i++) {
-		ssd->erase(std::to_string(0), std::to_string(3));
 		for (int LBA = 2; LBA < 100; LBA+=2) {
 			uint32_t value = dist(gen);
 			oss.str("");

--- a/SSD_TestShell/erase_and_write_aging_command.cpp
+++ b/SSD_TestShell/erase_and_write_aging_command.cpp
@@ -11,11 +11,15 @@ void EraseAndWriteAgingCommand::run(vector<string> commands) {
 		ssd->erase(std::to_string(0), std::to_string(3));
 		for (int LBA = 2; LBA < 100; LBA+=2) {
 			uint32_t value = dist(gen);
+			oss.str("");
+			oss.clear();
 			oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << value;
 			string randData = oss.str();
 			ssd->write(std::to_string(LBA), randData);
 			
 			value = dist(gen);
+			oss.str("");
+			oss.clear();
 			oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << value;
 			randData = oss.str();
 			ssd->write(std::to_string(LBA), randData);
@@ -27,6 +31,6 @@ void EraseAndWriteAgingCommand::run(vector<string> commands) {
 		}
 	}
 
-	std::cout << "PASS";
+	std::cout << "PASS\n";
 
 }

--- a/SSD_TestShell/full_write_and_read_compare_command.cpp
+++ b/SSD_TestShell/full_write_and_read_compare_command.cpp
@@ -9,21 +9,21 @@ void FullWriteAndReadCompareCommand::run(vector<string> commands) {
 
 	for (int i = 0; i < 100; i += 4) {
 		uint32_t value = dist(gen);
-	
+		oss.str("");
+		oss.clear();
+		oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << value;
+		string randData = oss.str();
 		for (int LBA = i; LBA < i + 4; LBA++) {
-			oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << value;
-			string randData = oss.str();
-
 			ssd->write(std::to_string(LBA), randData);
 			ssd->read(std::to_string(LBA));
 
 			bool result = cc->outputChecker(randData);
 			if (!result) {
-				std::cout << "FAIL";
+				std::cout << "FAIL\n";
 				return;
 			}
 		}
 	}
 
-	std::cout << "PASS";
+	std::cout << "PASS\n";
 }

--- a/SSD_TestShell/partial_lba_write_command.cpp
+++ b/SSD_TestShell/partial_lba_write_command.cpp
@@ -9,6 +9,8 @@ void PartialLBAWriteCommand::run(vector<string> commands) {
 
 	for (int i = 0; i < 30; i++) {
 		uint32_t value = dist(gen);
+		oss.str("");
+		oss.clear();
 		oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << value;
 		string randData = oss.str();
 
@@ -16,18 +18,18 @@ void PartialLBAWriteCommand::run(vector<string> commands) {
 		ssd->write(std::to_string(0), randData);
 		ssd->write(std::to_string(3), randData);
 		ssd->write(std::to_string(1), randData);
-		ssd->write(std::to_string(0), randData);
+		ssd->write(std::to_string(2), randData);
 
 		for (int LBA = 0; LBA < 5; LBA++) {
 			ssd->read(std::to_string(LBA));
 
 			bool result = cc->outputChecker(randData);
 			if (!result) {
-				std::cout << "FAIL";
+				std::cout << "FAIL\n";
 				return;
 			}
 		}
 	}
 
-	std::cout << "PASS";
+	std::cout << "PASS\n";
 }

--- a/SSD_TestShell/test_script_command_test.cpp
+++ b/SSD_TestShell/test_script_command_test.cpp
@@ -41,7 +41,7 @@ TEST_F(TestScriptFixture, FullWriteAndReadComapreCommand_Test1) {
 	
 	fullWriteAndReadComapre.run(commands);
 
-	EXPECT_EQ(oss.str(), "PASS");
+	EXPECT_EQ(oss.str(), "PASS\n");
 }
 
 TEST_F(TestScriptFixture, FullWriteAndReadComapreCommand_Test2) {
@@ -56,7 +56,7 @@ TEST_F(TestScriptFixture, FullWriteAndReadComapreCommand_Test2) {
 
 	fullWriteAndReadComapre.run(commands);
 
-	EXPECT_EQ(oss.str(), "FAIL");
+	EXPECT_EQ(oss.str(), "FAIL\n");
 }
 
 TEST_F(TestScriptFixture, FullWriteAndReadComapreCommand_Test3) {
@@ -73,7 +73,7 @@ TEST_F(TestScriptFixture, FullWriteAndReadComapreCommand_Test3) {
 
 	fullWriteAndReadComapre.run(commands);
 
-	EXPECT_EQ(oss.str(), "FAIL");
+	EXPECT_EQ(oss.str(), "FAIL\n");
 }
 
 TEST_F(TestScriptFixture, PartialLBAWrite_Test1) {
@@ -89,7 +89,7 @@ TEST_F(TestScriptFixture, PartialLBAWrite_Test1) {
 
 	partialLBAWrite.run(commands);
 
-	EXPECT_EQ(oss.str(), "PASS");
+	EXPECT_EQ(oss.str(), "PASS\n");
 }
 
 TEST_F(TestScriptFixture, PartialLBAWrite_Test2) {
@@ -105,7 +105,7 @@ TEST_F(TestScriptFixture, PartialLBAWrite_Test2) {
 
 	partialLBAWrite.run(commands);
 
-	EXPECT_EQ(oss.str(), "FAIL");
+	EXPECT_EQ(oss.str(), "FAIL\n");
 }
 
 TEST_F(TestScriptFixture, PartialLBAWrite_Test3) {
@@ -126,7 +126,7 @@ TEST_F(TestScriptFixture, PartialLBAWrite_Test3) {
 
 	partialLBAWrite.run(commands);
 
-	EXPECT_EQ(oss.str(), "FAIL");
+	EXPECT_EQ(oss.str(), "FAIL\n");
 }
 
 TEST_F(TestScriptFixture, WriteReadAgingCommand_Test1) {
@@ -142,7 +142,7 @@ TEST_F(TestScriptFixture, WriteReadAgingCommand_Test1) {
 
 	writeReadAging.run(commands);
 
-	EXPECT_EQ(oss.str(), "PASS");
+	EXPECT_EQ(oss.str(), "PASS\n");
 }
 
 TEST_F(TestScriptFixture, WriteReadAgingCommand_Test2) {
@@ -158,7 +158,7 @@ TEST_F(TestScriptFixture, WriteReadAgingCommand_Test2) {
 
 	writeReadAging.run(commands);
 
-	EXPECT_EQ(oss.str(), "FAIL");
+	EXPECT_EQ(oss.str(), "FAIL\n");
 }
 
 TEST_F(TestScriptFixture, WriteReadAgingCommand_Test3) {
@@ -175,7 +175,7 @@ TEST_F(TestScriptFixture, WriteReadAgingCommand_Test3) {
 
 	writeReadAging.run(commands);
 
-	EXPECT_EQ(oss.str(), "FAIL");
+	EXPECT_EQ(oss.str(), "FAIL\n");
 }
 
 TEST_F(TestScriptFixture, EraseAndWriteAging_Test1) {
@@ -188,5 +188,5 @@ TEST_F(TestScriptFixture, EraseAndWriteAging_Test1) {
 
 	eraseAndWriteAging.run(commands);
 
-	EXPECT_EQ(oss.str(), "PASS");
+	EXPECT_EQ(oss.str(), "PASS\n");
 }

--- a/SSD_TestShell/test_script_command_test.cpp
+++ b/SSD_TestShell/test_script_command_test.cpp
@@ -184,7 +184,7 @@ TEST_F(TestScriptFixture, EraseAndWriteAging_Test1) {
 	EXPECT_CALL(ssd, write(_, _))
 		.Times(2940);
 	EXPECT_CALL(ssd, erase(_, _))
-		.Times(1500);
+		.Times(1471);
 
 	eraseAndWriteAging.run(commands);
 

--- a/SSD_TestShell/write_read_aging_command.cpp
+++ b/SSD_TestShell/write_read_aging_command.cpp
@@ -9,6 +9,8 @@ void WriteReadAgingCommand::run(vector<string> commands) {
 
 	for (int i = 0; i < 200; i++) {
 		uint32_t value = dist(gen);
+		oss.str("");
+		oss.clear();
 		oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << value;
 		string randData = oss.str();
 
@@ -18,17 +20,17 @@ void WriteReadAgingCommand::run(vector<string> commands) {
 		ssd->read(std::to_string(0));
 		bool result = cc->outputChecker(randData);
 		if (!result) {
-			std::cout << "FAIL";
+			std::cout << "FAIL\n";
 			return;
 		}
 
 		ssd->read(std::to_string(99));
 		result = cc->outputChecker(randData);
 		if (!result) {
-			std::cout << "FAIL";
+			std::cout << "FAIL\n";
 			return;
 		}
 	}
 
-	std::cout << "PASS";
+	std::cout << "PASS\n";
 }


### PR DESCRIPTION
[fix] test script result add line break string & rand data string clear fix
- test script 에서 rand data string 값 초기화 코드 추가
- test script PASS, FAIL 결과 끝에 line break  문자 ('\n') 추가