### PR TITLE
[feat] Enable parser to handle erase-related commands

### DIFF
--- a/SSD_TestShell/SSD_TestShell.vcxproj
+++ b/SSD_TestShell/SSD_TestShell.vcxproj
@@ -104,6 +104,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -118,6 +119,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/SSD_TestShell/parser/validator_factory.h
+++ b/SSD_TestShell/parser/validator_factory.h
@@ -18,14 +18,14 @@ public:
 		if (command == "fullwrite") {
 			return std::make_unique<FullWriteValidator>();
 		}
-		if (command == "erase") {
+		if (command == "erase" || command == "erase_range") {
 			return std::make_unique<EraseValidator>();
 		}
 		if (command == "fullread" || command == "exit" || command == "help" || command == "flush") {
 			return std::make_unique<SimpleValidator>();
 		}
-		if (command == "1_" || command == "2_" || command == "3_" ||
-			command == "1_FullWriteAndReadCompare" || command == "2_PartialLBAWrite" || command == "3_WriteReadAging") {
+		if (command == "1_" || command == "2_" || command == "3_" || command == "4_" ||
+			command == "1_FullWriteAndReadCompare" || command == "2_PartialLBAWrite" || command == "3_WriteReadAging" || command ==	"Shell> 4_EraseAndWriteAging") {
 			return std::make_unique<ScriptValidator>();
 		}
 

--- a/SSD_TestShell/parser/validator_factory.h
+++ b/SSD_TestShell/parser/validator_factory.h
@@ -9,26 +9,34 @@
 class ValidatorFactory {
 public:
 	static std::unique_ptr<Validator> createValidator(const std::string& command) {
-		if (command == "read") {
+		if (command == READ_COMMAND) {
 			return std::make_unique<ReadValidator>();
 		}
-		if (command == "write") {
+		if (command == WRITE_COMMAND) {
 			return std::make_unique<WriteValidator>();
 		}
-		if (command == "fullwrite") {
+		if (command == FULLWRITE_COMMAND) {
 			return std::make_unique<FullWriteValidator>();
 		}
-		if (command == "erase" || command == "erase_range") {
+		if (ERASE_COMMANDS.contains(command)) {
 			return std::make_unique<EraseValidator>();
 		}
-		if (command == "fullread" || command == "exit" || command == "help" || command == "flush") {
+		if (SIMPLE_COMMANDS.contains(command)) {
 			return std::make_unique<SimpleValidator>();
 		}
-		if (command == "1_" || command == "2_" || command == "3_" || command == "4_" ||
-			command == "1_FullWriteAndReadCompare" || command == "2_PartialLBAWrite" || command == "3_WriteReadAging" || command ==	"Shell> 4_EraseAndWriteAging") {
+		if (SCRIPT_COMMANDS.contains(command)) {
 			return std::make_unique<ScriptValidator>();
 		}
-
 		throw std::invalid_argument("INVALID COMMAND");
 	}
+
+private:
+	static inline const std::string READ_COMMAND = "read";
+	static inline const std::string WRITE_COMMAND = "write";
+	static inline const std::string FULLWRITE_COMMAND = "fullwrite";
+	static inline const std::unordered_set<std::string> ERASE_COMMANDS = { "erase", "erase_range" };
+	static inline const std::unordered_set<std::string> SIMPLE_COMMANDS = { "fullread", "exit", "help", "flush" };
+	static inline const std::unordered_set<std::string> SCRIPT_COMMANDS =
+	{ "1_", "2_", "3_", "4_", "1_FullWriteAndReadCompare",
+	"2_PartialLBAWrite", "3_WriteReadAging", "4_EraseAndWriteAging" };
 };

--- a/SSD_TestShell/test/parser_test.cpp
+++ b/SSD_TestShell/test/parser_test.cpp
@@ -99,6 +99,12 @@ TEST_F(ParserFixture, EraseInvalidArgument) {
 	EXPECT_THROW(parser.parse("erase foo 30"), std::invalid_argument);
 }
 
+TEST_F(ParserFixture, EraseRangeSuccess) {
+	vector<string> actual = parser.parse("erase_range 20 22");
+	vector<string> expected = { "erase_range", "20", "22" };
+	EXPECT_EQ(expected, actual);
+}
+
 TEST_F(ParserFixture, FlushSuccess) {
 	vector<string> actual = parser.parse("flush");
 	vector<string> expected = { "flush" };


### PR DESCRIPTION
- erase_range과 erase 관련 script까지 parsing 가능하도록 구현했습니다.
- 관련 unit test 추가했습니다.
- validator factory에서 magic string을 제거하는 refactoring이 있었습니다.

*본 PR은 C++20의 기능을 사용하였으며 solution에도 이를 enable 했습니다.