### PR TITLE
[refactoring] Instead of generating the rand data directly in test_script, call utils->genRandData

### DIFF
--- a/SSD_TestShell/erase_and_write_aging_command.cpp
+++ b/SSD_TestShell/erase_and_write_aging_command.cpp
@@ -17,7 +17,7 @@ bool EraseAndWriteAgingCommand::run(vector<string> commands) {
 		}
 	}
 
-	std::cout << "PASS\n";
+	cout << "PASS\n";
 	return true;
 
 }

--- a/SSD_TestShell/full_write_and_read_compare_command.cpp
+++ b/SSD_TestShell/full_write_and_read_compare_command.cpp
@@ -1,30 +1,20 @@
 #include "full_write_and_read_compare_command.h"
 
-using std::cout;
-
 bool FullWriteAndReadCompareCommand::run(vector<string> commands) {
-	static std::mt19937 gen(std::random_device{}());
-	std::uniform_int_distribution<uint32_t>dist(0, 0xFFFFFFFF);
-	std::ostringstream oss;
-
-	for (int i = 0; i < 100; i += 4) {
-		uint32_t value = dist(gen);
-		oss.str("");
-		oss.clear();
-		oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << value;
-		string randData = oss.str();
+	for (int i = 0; i < MAX_LBA; i += 4) {
+		string randData = utils->genRandData();
 		for (int LBA = i; LBA < i + 4; LBA++) {
-			ssd->write(std::to_string(LBA), randData);
-			ssd->read(std::to_string(LBA));
+			ssd->write(to_string(LBA), randData);
+			ssd->read(to_string(LBA));
 
 			bool result = utils->outputChecker(randData);
 			if (!result) {
-				std::cout << "FAIL\n";
+				cout << "FAIL\n";
 				return false;
 			}
 		}
 	}
 
-	std::cout << "PASS\n";
+	cout << "PASS\n";
 	return true;
 }

--- a/SSD_TestShell/full_write_and_read_compare_command.h
+++ b/SSD_TestShell/full_write_and_read_compare_command.h
@@ -1,12 +1,6 @@
 #pragma once
 
 #include "command.h"
-#include <iomanip>
-#include <random>
-#include <iostream>
-#include <string>
-#include <sstream>
-#include <fstream>
 #include "ssd_handler.h"
 #include "utils.h"
 

--- a/SSD_TestShell/partial_lba_write_command.cpp
+++ b/SSD_TestShell/partial_lba_write_command.cpp
@@ -1,36 +1,26 @@
 #include "partial_lba_write_command.h"
 
-using std::cout;
-
 bool PartialLBAWriteCommand::run(vector<string> commands) {
-	static std::mt19937 gen(std::random_device{}());
-	std::uniform_int_distribution<uint32_t>dist(0, 0xFFFFFFFF);
-	std::ostringstream oss;
-
 	for (int i = 0; i < 30; i++) {
-		uint32_t value = dist(gen);
-		oss.str("");
-		oss.clear();
-		oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << value;
-		string randData = oss.str();
+		string randData = utils->genRandData();
 
-		ssd->write(std::to_string(4), randData);
-		ssd->write(std::to_string(0), randData);
-		ssd->write(std::to_string(3), randData);
-		ssd->write(std::to_string(1), randData);
-		ssd->write(std::to_string(2), randData);
+		ssd->write(to_string(4), randData);
+		ssd->write(to_string(0), randData);
+		ssd->write(to_string(3), randData);
+		ssd->write(to_string(1), randData);
+		ssd->write(to_string(2), randData);
 
 		for (int LBA = 0; LBA < 5; LBA++) {
-			ssd->read(std::to_string(LBA));
+			ssd->read(to_string(LBA));
 
 			bool result = utils->outputChecker(randData);
 			if (!result) {
-				std::cout << "FAIL\n";
+				cout << "FAIL\n";
 				return false;
 			}
 		}
 	}
 
-	std::cout << "PASS\n";
+	cout << "PASS\n";
 	return true;
 }

--- a/SSD_TestShell/partial_lba_write_command.h
+++ b/SSD_TestShell/partial_lba_write_command.h
@@ -1,12 +1,6 @@
 #pragma once
 
 #include "command.h"
-#include <iomanip>
-#include <random>
-#include <iostream>
-#include <string>
-#include <sstream>
-#include <fstream>
 #include "ssd_handler.h"
 #include "utils.h"
 

--- a/SSD_TestShell/ssd_client_app_test.cpp
+++ b/SSD_TestShell/ssd_client_app_test.cpp
@@ -141,6 +141,8 @@ TEST_F(SsdClientAppFixture, FullWriteAndReadComapreCommand_Test) {
 		.Times(100);
 	EXPECT_CALL(mockSsdHandler, read(_))
 		.Times(100);
+	EXPECT_CALL(mockUtils, genRandData())
+		.Times(25);
 	EXPECT_CALL(mockUtils, outputChecker(_))
 		.Times(100)
 		.WillRepeatedly(Return(true));
@@ -155,6 +157,8 @@ TEST_F(SsdClientAppFixture, PartialLBAWrite_Test) {
 		.Times(150);
 	EXPECT_CALL(mockSsdHandler, read(_))
 		.Times(150);
+	EXPECT_CALL(mockUtils, genRandData())
+		.Times(30);
 	EXPECT_CALL(mockUtils, outputChecker(_))
 		.Times(150)
 		.WillRepeatedly(Return(true));
@@ -169,6 +173,8 @@ TEST_F(SsdClientAppFixture, WriteReadAgingCommand_Test) {
 		.Times(400);
 	EXPECT_CALL(mockSsdHandler, read(_))
 		.Times(400);
+	EXPECT_CALL(mockUtils, genRandData())
+		.Times(200);
 	EXPECT_CALL(mockUtils, outputChecker(_))
 		.Times(400)
 		.WillRepeatedly(Return(true));

--- a/SSD_TestShell/test_script_command_test.cpp
+++ b/SSD_TestShell/test_script_command_test.cpp
@@ -4,9 +4,6 @@
 #include "write_read_aging_command.h"
 #include "erase_and_write_aging_command.h"
 
-#include <iostream>
-#include <sstream>
-
 using namespace testing;
 
 class TestScriptFixture : public Test {
@@ -35,6 +32,8 @@ TEST_F(TestScriptFixture, FullWriteAndReadComapreCommand_Test1) {
 		.Times(100);
 	EXPECT_CALL(ssd, read(_))
 		.Times(100);
+	EXPECT_CALL(utils, genRandData())
+		.Times(25);
 	EXPECT_CALL(utils, outputChecker(_))
 		.Times(100)
 		.WillRepeatedly(Return(true));
@@ -51,6 +50,8 @@ TEST_F(TestScriptFixture, FullWriteAndReadComapreCommand_Test2) {
 		.Times(1);
 	EXPECT_CALL(ssd, read(_))
 		.Times(1);
+	EXPECT_CALL(utils, genRandData())
+		.Times(1);
 	EXPECT_CALL(utils, outputChecker(_))
 		.WillRepeatedly(Return(false));
 
@@ -66,6 +67,8 @@ TEST_F(TestScriptFixture, FullWriteAndReadComapreCommand_Test3) {
 		.Times(2);
 	EXPECT_CALL(ssd, read(_))
 		.Times(2);
+	EXPECT_CALL(utils, genRandData())
+		.Times(1);
 	EXPECT_CALL(utils, outputChecker(_))
 		.Times(2)
 		.WillOnce(Return(true))
@@ -83,6 +86,8 @@ TEST_F(TestScriptFixture, PartialLBAWrite_Test1) {
 		.Times(150);
 	EXPECT_CALL(ssd, read(_))
 		.Times(150);
+	EXPECT_CALL(utils, genRandData())
+		.Times(30);
 	EXPECT_CALL(utils, outputChecker(_))
 		.Times(150)
 		.WillRepeatedly(Return(true));
@@ -98,6 +103,8 @@ TEST_F(TestScriptFixture, PartialLBAWrite_Test2) {
 	EXPECT_CALL(ssd, write(_, _))
 		.Times(5);
 	EXPECT_CALL(ssd, read(_))
+		.Times(1);
+	EXPECT_CALL(utils, genRandData())
 		.Times(1);
 	EXPECT_CALL(utils, outputChecker(_))
 		.Times(1)
@@ -115,6 +122,8 @@ TEST_F(TestScriptFixture, PartialLBAWrite_Test3) {
 		.Times(10);
 	EXPECT_CALL(ssd, read(_))
 		.Times(6);
+	EXPECT_CALL(utils, genRandData())
+		.Times(2);
 	EXPECT_CALL(utils, outputChecker(_))
 		.Times(6)
 		.WillOnce(Return(true))
@@ -136,6 +145,8 @@ TEST_F(TestScriptFixture, WriteReadAgingCommand_Test1) {
 		.Times(400);
 	EXPECT_CALL(ssd, read(_))
 		.Times(400);
+	EXPECT_CALL(utils, genRandData())
+		.Times(200);
 	EXPECT_CALL(utils, outputChecker(_))
 		.Times(400)
 		.WillRepeatedly(Return(true));
@@ -151,6 +162,8 @@ TEST_F(TestScriptFixture, WriteReadAgingCommand_Test2) {
 	EXPECT_CALL(ssd, write(_, _))
 		.Times(2);
 	EXPECT_CALL(ssd, read(_))
+		.Times(1);
+	EXPECT_CALL(utils, genRandData())
 		.Times(1);
 	EXPECT_CALL(utils, outputChecker(_))
 		.Times(1)
@@ -168,6 +181,8 @@ TEST_F(TestScriptFixture, WriteReadAgingCommand_Test3) {
 		.Times(2);
 	EXPECT_CALL(ssd, read(_))
 		.Times(2);
+	EXPECT_CALL(utils, genRandData())
+		.Times(1);
 	EXPECT_CALL(utils, outputChecker(_))
 		.Times(2)
 		.WillOnce(Return(true))

--- a/SSD_TestShell/utils.h
+++ b/SSD_TestShell/utils.h
@@ -1,10 +1,12 @@
 #pragma once
 #include "gmock/gmock.h"
+#include <iostream>
 #include <string>
 #include <random>
 #include <sstream>
 #include <fstream>
 
+using std::cout;
 using std::string;
 using std::to_string;
 

--- a/SSD_TestShell/write_read_aging_command.cpp
+++ b/SSD_TestShell/write_read_aging_command.cpp
@@ -1,37 +1,27 @@
 #include "write_read_aging_command.h"
 
-using std::cout;
-
 bool WriteReadAgingCommand::run(vector<string> commands) {
-	static std::mt19937 gen(std::random_device{}());
-	std::uniform_int_distribution<uint32_t>dist(0, 0xFFFFFFFF);
-	std::ostringstream oss;
-
 	for (int i = 0; i < 200; i++) {
-		uint32_t value = dist(gen);
-		oss.str("");
-		oss.clear();
-		oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << value;
-		string randData = oss.str();
+		string randData = utils->genRandData();
 
-		ssd->write(std::to_string(0), randData);
-		ssd->write(std::to_string(99), randData);
+		ssd->write(to_string(0), randData);
+		ssd->write(to_string(99), randData);
 
-		ssd->read(std::to_string(0));
+		ssd->read(to_string(0));
 		bool result = utils->outputChecker(randData);
 		if (!result) {
-			std::cout << "FAIL\n";
+			cout << "FAIL\n";
 			return false;
 		}
 
-		ssd->read(std::to_string(99));
+		ssd->read(to_string(99));
 		result = utils->outputChecker(randData);
 		if (!result) {
-			std::cout << "FAIL\n";
+			cout << "FAIL\n";
 			return false;
 		}
 	}
 
-	std::cout << "PASS\n";
+	cout << "PASS\n";
 	return true;
 }

--- a/SSD_TestShell/write_read_aging_command.h
+++ b/SSD_TestShell/write_read_aging_command.h
@@ -1,12 +1,6 @@
 #pragma once
 
 #include "command.h"
-#include <iomanip>
-#include <random>
-#include <iostream>
-#include <string>
-#include <sstream>
-#include <fstream>
 #include "ssd_handler.h"
 #include "utils.h"
 


### PR DESCRIPTION
[refactoring] Instead of generating the rand data directly in test_script, call utils->genRandData
- test script에서 rand data를 직접 생성하다보니 중복 코드가 있었는데, utils에 genRandData가 있으므로 이를 호출하도록 refactoring 하였습니다.