### PR TITLE
[refactoring] RunnerTest, SsdClientAppTest Refactoring

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -45,6 +45,10 @@ jobs:
     - name: Build SSD_TestShell.sln
       run: msbuild SSD_TestShell/SSD_TestShell.sln /p:Configuration=Debug /p:Platform=x64
 
+    - name: Copy shell_script.txt to output directory
+      shell: cmd
+      run: copy SSD_TestShell\shell_script.txt SSD_TestShell\x64\Debug\
+
     - name: Run SSD_TestShellTests
       run: SSD_TestShell\x64\Debug\SSD_TestShell.exe --gtest_output=xml:test-results-shell.xml
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Copy shell_script.txt to output directory
       shell: cmd
-      run: copy SSD_TestShell\shell_script.txt SSD_TestShell\x64\Debug\
+      run: copy SSD_TestShell\shell_script.txt .
 
     - name: Run SSD_TestShellTests
       run: SSD_TestShell\x64\Debug\SSD_TestShell.exe --gtest_output=xml:test-results-shell.xml

--- a/SSD_TestShell/main.cpp
+++ b/SSD_TestShell/main.cpp
@@ -13,14 +13,14 @@ int main(int argc, char** argv) {
 int main(int argc, char* argv[]) {
     SsdHandler ssdHandler;
     Utils utils;
-    SsdClientApp app;
-    Runner runner;
+    SsdClientApp app(&ssdHandler, &utils);
+    Runner runner(&ssdHandler, &utils);
 
     if (argc == 1) {
         while (true) {
             try {
                 app.getUserCmdLine();
-                app.startVerify(&ssdHandler, &utils);
+                app.startVerify();
             }
             catch (const std::invalid_argument& e) {
                 std::cout << e.what() << '\n';

--- a/SSD_TestShell/runner.cpp
+++ b/SSD_TestShell/runner.cpp
@@ -27,9 +27,11 @@ void Runner::executeAllTest(std::ifstream& fin)
     }
 }
 
-void Runner::printCmd(std::string& command)
+void Runner::printCmd(const string& command)
 {
-    cout << std::left << std::setw(30) << command << " ___   Run...";
+    std::ostringstream oss;
+    oss << std::setfill(' ') << std::left << std::setw(27) << command << " ___   Run...";
+    cout << oss.str();
 }
 
 bool Runner::isValidPath(std::ifstream& fin)
@@ -42,10 +44,8 @@ bool Runner::isValidPath(std::ifstream& fin)
 }
 
 bool Runner::executeOneTest(const string& cmd) {
-    SsdHandler ssdHandler;
-    Utils utils;
-    SsdClientApp app;
+    SsdClientApp app(ssdInterface, utilsInterface);
 
     app.setInputCmd(cmd);
-    return app.startVerify(&ssdHandler, &utils);
+    return app.startVerify();
 }

--- a/SSD_TestShell/runner.h
+++ b/SSD_TestShell/runner.h
@@ -1,13 +1,19 @@
 #pragma once
 #include <string>
 #include <sstream>
+#include "ssd_handler.h"
+#include "utils.h"
 
 class Runner {
 public:
+    Runner(SsdInterface* ssd, UtilsInterface* utils) : ssdInterface{ ssd }, utilsInterface{ utils } {}
     void runScriptFile(const std::string& filePath);
     void executeAllTest(std::ifstream& fin);
-    void printCmd(std::string& command);
+    
 private:
     bool isValidPath(std::ifstream& fin);
     bool executeOneTest(const std::string& cmd);
+    void printCmd(const std::string& command);
+    SsdInterface* ssdInterface;
+    UtilsInterface* utilsInterface;
 };

--- a/SSD_TestShell/ssd_client_app.cpp
+++ b/SSD_TestShell/ssd_client_app.cpp
@@ -9,11 +9,11 @@ using std::vector;
 using std::cout;
 using std::cin;
 
-bool SsdClientApp::startVerify(SsdInterface* sdInterface, UtilsInterface* utilsInterface) {
+bool SsdClientApp::startVerify() {
 	Parser parser;
 	vector<string> parsedInput = parser.parse(inputCmd);
 	
-	CommandProcessor commandProcesser{ sdInterface, utilsInterface };
+	CommandProcessor commandProcesser{ ssdInterface, utilsInterface };
 	return commandProcesser.run(parsedInput);
 }
 

--- a/SSD_TestShell/ssd_client_app.h
+++ b/SSD_TestShell/ssd_client_app.h
@@ -6,7 +6,8 @@
 
 class SsdClientApp {
 public:
-	bool startVerify(SsdInterface* sdInterface, UtilsInterface* utilsInterface);
+	SsdClientApp(SsdInterface* ssd, UtilsInterface* utils) : ssdInterface{ ssd }, utilsInterface{ utils } {}
+	bool startVerify();
 	void setInputCmd(std::string input);
 	void getUserCmdLine();
 	void printError();
@@ -15,4 +16,6 @@ private:
 	void displayPrompt() const;
 	std::string readUserInput();
 	std::string inputCmd;
+	SsdInterface* ssdInterface;
+	UtilsInterface* utilsInterface;
 };

--- a/SSD_TestShell/ssd_client_app_test.cpp
+++ b/SSD_TestShell/ssd_client_app_test.cpp
@@ -11,7 +11,7 @@ class SsdClientAppFixture : public Test {
 public:
 	SsdHandlerMock mockSsdHandler;
 	UtilsMock mockUtils;
-	SsdClientApp app;
+	SsdClientApp app{ &mockSsdHandler, &mockUtils };
 
 	std::ostringstream oss;
 	std::streambuf* old_buf;
@@ -24,6 +24,7 @@ public:
 	const string USER_SCRIPT1_CMD = "1_";
 	const string USER_SCRIPT2_CMD = "2_";
 	const string USER_SCRIPT3_CMD = "3_";
+	const string USER_SCRIPT4_CMD = "4_";
 
 	const string LBA = "0";
 	const string DEFAULT_DATA = "0x00000000";
@@ -69,7 +70,7 @@ public:
 
 	void doClientApp(string userCmd) {
 		app.setInputCmd(userCmd);
-		app.startVerify(&mockSsdHandler, &mockUtils);
+		app.startVerify();
 	}
 
 private:
@@ -180,6 +181,19 @@ TEST_F(SsdClientAppFixture, WriteReadAgingCommand_Test) {
 		.WillRepeatedly(Return(true));
 
 	doClientApp(USER_SCRIPT3_CMD);
+
+	EXPECT_EQ(oss.str(), "PASS\n");
+}
+
+TEST_F(SsdClientAppFixture, EraseAndWriteAging_Test) {
+	EXPECT_CALL(mockSsdHandler, write(_, _))
+		.Times(2940);
+	EXPECT_CALL(mockSsdHandler, erase(_, _))
+		.Times(1471);
+	EXPECT_CALL(mockUtils, genSSDRandData())
+		.Times(2940);
+
+	doClientApp(USER_SCRIPT4_CMD);
 
 	EXPECT_EQ(oss.str(), "PASS\n");
 }

--- a/SSD_TestShell/test/runner_test.cpp
+++ b/SSD_TestShell/test/runner_test.cpp
@@ -28,8 +28,7 @@ TEST(Runner, AllScriptSuccess) {
 		.Times(650)
 		.WillRepeatedly(Return(true));
 
-	std::filesystem::path path = std::filesystem::current_path();
-	runner.runScriptFile(path.string() + "//shell_script.txt");
+	runner.runScriptFile("shell_script.txt");
 }
 
 

--- a/SSD_TestShell/test/runner_test.cpp
+++ b/SSD_TestShell/test/runner_test.cpp
@@ -7,15 +7,29 @@
 
 #include <iostream>
 #include <sstream>
+#include <filesystem>
 
 using namespace testing;
 
-// TODO
 TEST(Runner, AllScriptSuccess) {
-	// Runner runner;
-	// runner.runScriptFile("shell_script.txt");
+	SsdHandlerMock mockSsdHandler;
+	UtilsMock mockUtils;
+	Runner runner{ &mockSsdHandler, &mockUtils };
 
-	EXPECT_EQ(1, 1);
+	EXPECT_CALL(mockSsdHandler, write(_, _))
+		.Times(3590);
+	EXPECT_CALL(mockSsdHandler, read(_))
+		.Times(650);
+	EXPECT_CALL(mockSsdHandler, erase(_, _))
+		.Times(1471);
+	EXPECT_CALL(mockUtils, genSSDRandData())
+		.Times(3195);
+	EXPECT_CALL(mockUtils, outputChecker(_))
+		.Times(650)
+		.WillRepeatedly(Return(true));
+
+	std::filesystem::path path = std::filesystem::current_path();
+	runner.runScriptFile(path.string() + "//shell_script.txt");
 }
 
 


### PR DESCRIPTION
RunnerTest, SsdClientAppTest Refactoring건 입니다.
SsdHandler와 Utils를 생성자에서 주입할 수 있게 변경했습니다.
Runner Test는 실제 수행시 많은 시간이 걸려 SsdHandler와 Utils를 Mock으로 변경하여 Test했습니다.
shell script test시 출력 스트림이 다른 Test에 영향을 끼치는 버그가 발생해 출력 스트림을 따로 만들어 print하게 변경했습니다.