### PR TITLE
[refactoring] utils refactoring

### DIFF
--- a/SSD_TestShell/erase_and_write_aging_command.cpp
+++ b/SSD_TestShell/erase_and_write_aging_command.cpp
@@ -4,10 +4,10 @@ bool EraseAndWriteAgingCommand::run(vector<string> commands) {
 	ssd->erase(to_string(0), to_string(3));
 	for (int i = 0; i < 30; i++) {
 		for (int LBA = 2; LBA < MAX_LBA; LBA += 2) {
-			string randData = utils->genRandData();
+			string randData = utils->genSSDRandData();
 			ssd->write(to_string(LBA), randData);
 
-			randData = utils->genRandData();
+			randData = utils->genSSDRandData();
 			ssd->write(to_string(LBA), randData);
 
 			if ((LBA + 3) > MAX_LBA)

--- a/SSD_TestShell/full_write_and_read_compare_command.cpp
+++ b/SSD_TestShell/full_write_and_read_compare_command.cpp
@@ -2,7 +2,7 @@
 
 bool FullWriteAndReadCompareCommand::run(vector<string> commands) {
 	for (int i = 0; i < MAX_LBA; i += 4) {
-		string randData = utils->genRandData();
+		string randData = utils->genSSDRandData();
 		for (int LBA = i; LBA < i + 4; LBA++) {
 			ssd->write(to_string(LBA), randData);
 			ssd->read(to_string(LBA));

--- a/SSD_TestShell/partial_lba_write_command.cpp
+++ b/SSD_TestShell/partial_lba_write_command.cpp
@@ -2,7 +2,7 @@
 
 bool PartialLBAWriteCommand::run(vector<string> commands) {
 	for (int i = 0; i < 30; i++) {
-		string randData = utils->genRandData();
+		string randData = utils->genSSDRandData();
 
 		ssd->write(to_string(4), randData);
 		ssd->write(to_string(0), randData);

--- a/SSD_TestShell/ssd_client_app_test.cpp
+++ b/SSD_TestShell/ssd_client_app_test.cpp
@@ -141,7 +141,7 @@ TEST_F(SsdClientAppFixture, FullWriteAndReadComapreCommand_Test) {
 		.Times(100);
 	EXPECT_CALL(mockSsdHandler, read(_))
 		.Times(100);
-	EXPECT_CALL(mockUtils, genRandData())
+	EXPECT_CALL(mockUtils, genSSDRandData())
 		.Times(25);
 	EXPECT_CALL(mockUtils, outputChecker(_))
 		.Times(100)
@@ -157,7 +157,7 @@ TEST_F(SsdClientAppFixture, PartialLBAWrite_Test) {
 		.Times(150);
 	EXPECT_CALL(mockSsdHandler, read(_))
 		.Times(150);
-	EXPECT_CALL(mockUtils, genRandData())
+	EXPECT_CALL(mockUtils, genSSDRandData())
 		.Times(30);
 	EXPECT_CALL(mockUtils, outputChecker(_))
 		.Times(150)
@@ -173,7 +173,7 @@ TEST_F(SsdClientAppFixture, WriteReadAgingCommand_Test) {
 		.Times(400);
 	EXPECT_CALL(mockSsdHandler, read(_))
 		.Times(400);
-	EXPECT_CALL(mockUtils, genRandData())
+	EXPECT_CALL(mockUtils, genSSDRandData())
 		.Times(200);
 	EXPECT_CALL(mockUtils, outputChecker(_))
 		.Times(400)

--- a/SSD_TestShell/test_script_command_test.cpp
+++ b/SSD_TestShell/test_script_command_test.cpp
@@ -32,7 +32,7 @@ TEST_F(TestScriptFixture, FullWriteAndReadComapreCommand_Test1) {
 		.Times(100);
 	EXPECT_CALL(ssd, read(_))
 		.Times(100);
-	EXPECT_CALL(utils, genRandData())
+	EXPECT_CALL(utils, genSSDRandData())
 		.Times(25);
 	EXPECT_CALL(utils, outputChecker(_))
 		.Times(100)
@@ -50,7 +50,7 @@ TEST_F(TestScriptFixture, FullWriteAndReadComapreCommand_Test2) {
 		.Times(1);
 	EXPECT_CALL(ssd, read(_))
 		.Times(1);
-	EXPECT_CALL(utils, genRandData())
+	EXPECT_CALL(utils, genSSDRandData())
 		.Times(1);
 	EXPECT_CALL(utils, outputChecker(_))
 		.WillRepeatedly(Return(false));
@@ -67,7 +67,7 @@ TEST_F(TestScriptFixture, FullWriteAndReadComapreCommand_Test3) {
 		.Times(2);
 	EXPECT_CALL(ssd, read(_))
 		.Times(2);
-	EXPECT_CALL(utils, genRandData())
+	EXPECT_CALL(utils, genSSDRandData())
 		.Times(1);
 	EXPECT_CALL(utils, outputChecker(_))
 		.Times(2)
@@ -86,7 +86,7 @@ TEST_F(TestScriptFixture, PartialLBAWrite_Test1) {
 		.Times(150);
 	EXPECT_CALL(ssd, read(_))
 		.Times(150);
-	EXPECT_CALL(utils, genRandData())
+	EXPECT_CALL(utils, genSSDRandData())
 		.Times(30);
 	EXPECT_CALL(utils, outputChecker(_))
 		.Times(150)
@@ -104,7 +104,7 @@ TEST_F(TestScriptFixture, PartialLBAWrite_Test2) {
 		.Times(5);
 	EXPECT_CALL(ssd, read(_))
 		.Times(1);
-	EXPECT_CALL(utils, genRandData())
+	EXPECT_CALL(utils, genSSDRandData())
 		.Times(1);
 	EXPECT_CALL(utils, outputChecker(_))
 		.Times(1)
@@ -122,7 +122,7 @@ TEST_F(TestScriptFixture, PartialLBAWrite_Test3) {
 		.Times(10);
 	EXPECT_CALL(ssd, read(_))
 		.Times(6);
-	EXPECT_CALL(utils, genRandData())
+	EXPECT_CALL(utils, genSSDRandData())
 		.Times(2);
 	EXPECT_CALL(utils, outputChecker(_))
 		.Times(6)
@@ -145,7 +145,7 @@ TEST_F(TestScriptFixture, WriteReadAgingCommand_Test1) {
 		.Times(400);
 	EXPECT_CALL(ssd, read(_))
 		.Times(400);
-	EXPECT_CALL(utils, genRandData())
+	EXPECT_CALL(utils, genSSDRandData())
 		.Times(200);
 	EXPECT_CALL(utils, outputChecker(_))
 		.Times(400)
@@ -163,7 +163,7 @@ TEST_F(TestScriptFixture, WriteReadAgingCommand_Test2) {
 		.Times(2);
 	EXPECT_CALL(ssd, read(_))
 		.Times(1);
-	EXPECT_CALL(utils, genRandData())
+	EXPECT_CALL(utils, genSSDRandData())
 		.Times(1);
 	EXPECT_CALL(utils, outputChecker(_))
 		.Times(1)
@@ -181,7 +181,7 @@ TEST_F(TestScriptFixture, WriteReadAgingCommand_Test3) {
 		.Times(2);
 	EXPECT_CALL(ssd, read(_))
 		.Times(2);
-	EXPECT_CALL(utils, genRandData())
+	EXPECT_CALL(utils, genSSDRandData())
 		.Times(1);
 	EXPECT_CALL(utils, outputChecker(_))
 		.Times(2)
@@ -200,7 +200,7 @@ TEST_F(TestScriptFixture, EraseAndWriteAging_Test1) {
 		.Times(2940);
 	EXPECT_CALL(ssd, erase(_, _))
 		.Times(1471);
-	EXPECT_CALL(utils, genRandData())
+	EXPECT_CALL(utils, genSSDRandData())
 		.Times(2940);
 
 	eraseAndWriteAging.run(commands);

--- a/SSD_TestShell/utils.cpp
+++ b/SSD_TestShell/utils.cpp
@@ -1,43 +1,29 @@
 #include "utils.h"
 
-Utils::Utils() : gen(std::random_device{}()), dist(0, 0xFFFFFFFF) {
-}
+Utils::Utils() : gen(std::random_device{}()), dist(0, 0xFFFFFFFF) {}
 
 bool Utils::outputChecker(const string& data) {
-	std::ifstream ssdOutput("ssd_output.txt");
-	string outputData;
-
-	if (ssdOutput.is_open()) {
-		if (!std::getline(ssdOutput, outputData)) return false;
-	}
-	ssdOutput.close();
-
+    string outputData = this->readOutput();
 	if (outputData != data) return false;
 	return true;
 }
 
 string Utils::readOutput() {
-    char curDir[1000];
-    _getcwd(curDir, 1000);
-    string filePath(curDir);
-    filePath += "//ssd_output.txt";
+    std::ifstream ssdOutput("ssd_output.txt");
+    string outputData;
 
-    std::ifstream file(filePath);
-
-    if (!file.is_open()) {
+    if (!ssdOutput.is_open()) {
         std::cerr << "file open fail" << std::endl;
         return "";
     }
 
-    std::string line = "";
-    getline(file, line);
+    if (!std::getline(ssdOutput, outputData)) return "";
+    ssdOutput.close();
 
-    file.close();
-
-    return line;
+    return outputData;
 }
 
-string Utils::genRandData() {
+string Utils::genSSDRandData() {
     oss.str("");
     oss.clear();
     oss << "0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << dist(gen);

--- a/SSD_TestShell/utils.h
+++ b/SSD_TestShell/utils.h
@@ -16,7 +16,7 @@ interface UtilsInterface {
 public:
 	virtual string readOutput() = 0;
 	virtual bool outputChecker(const string& data) = 0;
-	virtual string genRandData() = 0;
+	virtual string genSSDRandData() = 0;
 };
 
 class Utils : public UtilsInterface {
@@ -24,7 +24,7 @@ public:
 	Utils();
 	string readOutput() override;
 	bool outputChecker(const string& data) override;
-	string genRandData() override;
+	string genSSDRandData() override;
 private:
 	std::mt19937 gen;
 	std::uniform_int_distribution<uint32_t> dist;
@@ -35,5 +35,5 @@ class UtilsMock : public UtilsInterface {
 public:
 	MOCK_METHOD(string, readOutput, (), (override));
 	MOCK_METHOD(bool, outputChecker, (const string&), (override));
-	MOCK_METHOD(string, genRandData, (), (override));
+	MOCK_METHOD(string, genSSDRandData, (), (override));
 };

--- a/SSD_TestShell/write_read_aging_command.cpp
+++ b/SSD_TestShell/write_read_aging_command.cpp
@@ -2,7 +2,7 @@
 
 bool WriteReadAgingCommand::run(vector<string> commands) {
 	for (int i = 0; i < 200; i++) {
-		string randData = utils->genRandData();
+		string randData = utils->genSSDRandData();
 
 		ssd->write(to_string(0), randData);
 		ssd->write(to_string(99), randData);


### PR DESCRIPTION
[refactoring] utils refactoring
- utils의 genRandData 이름에 혼동이 있을 수 있어서 genSSDRandData로 변경하였습니다.
- readOutput와 outputChecker의 동작이 대부분 겹쳐서 outputChecker에서 readOutput을 호출하도록 변경