### PR TITLE
[refactoring] runner strategy pattern enable

### DIFF
--- a/SSD_TestShell/SSD_TestShell.vcxproj
+++ b/SSD_TestShell/SSD_TestShell.vcxproj
@@ -150,6 +150,7 @@
     <ClCompile Include="partial_lba_write_command.cpp" />
     <ClCompile Include="read_command.cpp" />
     <ClCompile Include="runner.cpp" />
+    <ClCompile Include="ssd_client_test_strategy.cpp" />
     <ClCompile Include="ssd_handler.cpp" />
     <ClCompile Include="ssd_client_app.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)\parser;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -196,6 +197,7 @@
     <ClInclude Include="partial_lba_write_command.h" />
     <ClInclude Include="read_command.h" />
     <ClInclude Include="runner.h" />
+    <ClInclude Include="script_strategy_interface.h" />
     <ClInclude Include="ssd_handler.h" />
     <ClInclude Include="ssd_client_app.h" />
     <ClInclude Include="utils.h" />

--- a/SSD_TestShell/main.cpp
+++ b/SSD_TestShell/main.cpp
@@ -8,13 +8,15 @@ int main(int argc, char** argv) {
 #else
 #include "ssd_client_app.h"
 #include "runner.h"
+#include "script_strategy_interface.h"
 #include <iostream>
 
 int main(int argc, char* argv[]) {
     SsdHandler ssdHandler;
     Utils utils;
     SsdClientApp app(&ssdHandler, &utils);
-    Runner runner(&ssdHandler, &utils);
+    auto ssdClientStrategy = std::make_unique<SsdClientTestStrategy>(&ssdHandler, &utils);
+    Runner runner(std::move(ssdClientStrategy));
 
     if (argc == 1) {
         while (true) {

--- a/SSD_TestShell/runner.cpp
+++ b/SSD_TestShell/runner.cpp
@@ -44,8 +44,9 @@ bool Runner::isValidPath(std::ifstream& fin)
 }
 
 bool Runner::executeOneTest(const string& cmd) {
-    SsdClientApp app(ssdInterface, utilsInterface);
-
-    app.setInputCmd(cmd);
-    return app.startVerify();
+    if (!testStrategy) {
+        std::cerr << "Error: Test strategy is not set.\n";
+        return false;
+    }
+    return testStrategy->execute(cmd);
 }

--- a/SSD_TestShell/runner.h
+++ b/SSD_TestShell/runner.h
@@ -1,19 +1,22 @@
 #pragma once
 #include <string>
 #include <sstream>
-#include "ssd_handler.h"
 #include "utils.h"
+#include "script_strategy_interface.h"
 
 class Runner {
 public:
-    Runner(SsdInterface* ssd, UtilsInterface* utils) : ssdInterface{ ssd }, utilsInterface{ utils } {}
+    Runner(std::unique_ptr<ScriptStrategyInterface> strategy)
+        : testStrategy(std::move(strategy)) {
+    }
+
     void runScriptFile(const std::string& filePath);
     void executeAllTest(std::ifstream& fin);
-    
+
 private:
     bool isValidPath(std::ifstream& fin);
     bool executeOneTest(const std::string& cmd);
     void printCmd(const std::string& command);
-    SsdInterface* ssdInterface;
-    UtilsInterface* utilsInterface;
+
+    std::unique_ptr<ScriptStrategyInterface> testStrategy;
 };

--- a/SSD_TestShell/script_strategy_interface.h
+++ b/SSD_TestShell/script_strategy_interface.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <string>
+#include "ssd_client_app.h"
+
+#define interface class
+
+interface ScriptStrategyInterface {
+public:
+    virtual ~ScriptStrategyInterface() = default;
+    virtual bool execute(const std::string& cmd) = 0;
+};
+
+class SsdClientTestStrategy : public ScriptStrategyInterface {
+public:
+    SsdClientTestStrategy(SsdInterface* ssd, UtilsInterface* utils)
+        : ssdInterface(ssd), utilsInterface(utils) {
+    }
+
+    bool execute(const std::string& cmd) override;
+
+private:
+    SsdInterface* ssdInterface;
+    UtilsInterface* utilsInterface;
+};

--- a/SSD_TestShell/ssd_client_test_strategy.cpp
+++ b/SSD_TestShell/ssd_client_test_strategy.cpp
@@ -1,0 +1,7 @@
+#include "script_strategy_interface.h"
+
+bool SsdClientTestStrategy::execute(const std::string& cmd) {
+    SsdClientApp app(ssdInterface, utilsInterface);
+    app.setInputCmd(cmd);
+    return app.startVerify();
+}

--- a/SSD_TestShell/test/runner_test.cpp
+++ b/SSD_TestShell/test/runner_test.cpp
@@ -14,7 +14,8 @@ using namespace testing;
 TEST(Runner, AllScriptSuccess) {
 	SsdHandlerMock mockSsdHandler;
 	UtilsMock mockUtils;
-	Runner runner{ &mockSsdHandler, &mockUtils };
+	auto ssdClientStrategy = std::make_unique<SsdClientTestStrategy>(&mockSsdHandler, &mockUtils);
+	Runner runner(std::move(ssdClientStrategy));
 
 	EXPECT_CALL(mockSsdHandler, write(_, _))
 		.Times(3590);


### PR DESCRIPTION
Runner에 전략 패턴을 도입했습니다.
현재 script를 실행하기 위해 txt를 읽은 후 SsdClientApp을 통해 ssd read/write를 수행하게 되는데
추후에 SsdClientApp이 아닌 다양한 script를 실행해야할 때 확장을 더 쉽게 하기 위해 적용했습니다.