### PR TITLE
[fix] remove remaining magic string in logger and fix related errors

### DIFF
--- a/SSD_TestShell/logger/logger.cpp
+++ b/SSD_TestShell/logger/logger.cpp
@@ -84,7 +84,7 @@ string Logger::padMethodName(const string& methodName, size_t width) {
 }
 
 void Logger::saveAsLogFile() {
-	string src = "latest.log";
+	string src = logFile;
 	string dst = generateLogFilename();
 
 	if (!std::filesystem::exists(src)) return;

--- a/SSD_TestShell/test/logger_test.cpp
+++ b/SSD_TestShell/test/logger_test.cpp
@@ -22,7 +22,7 @@ public:
 	string minuteAfterZipFile;
 
 	void createLargeLogFile() {
-		std::ofstream out("latest.log", std::ios::binary);
+		std::ofstream out(logFile, std::ios::binary);
 		std::vector<char> buffer(10240, 'A');
 		out.write(buffer.data(), buffer.size());
 		out.flush();


### PR DESCRIPTION
Magic String 제거하면서 빼먹은 부분때문에 발생하던 logging 관련 error를 고쳤습니다.

이제 .log 파일, .zip 파일이 정상적으로 생성됩니다.